### PR TITLE
📝 Docs: Document core pipeline components and registration

### DIFF
--- a/logpipe.go
+++ b/logpipe.go
@@ -7,21 +7,32 @@ import (
 func nop(_ ...interface {}) {
 }
 
+// Source represents a log provider in the pipeline.
+// Implementations should continuously emit log lines (e.g., from journalctl or a file)
+// to the channel returned by GetSource.
 type Source interface {
     GetSource() <-chan string // Sources can only provide lines
 }
 
+// Sink represents a log consumer in the pipeline.
+// Implementations should read from the channel returned by GetSink
+// and forward the logs to external services (e.g., Telegram, Discord).
 type Sink interface {
     GetSink() chan <- string // Sinks can only consume lines
 }
 
-
+// LogPipe is the central hub connecting Sources and Sinks.
+// It manages the registration of components and handles the broadcasting
+// of messages from all registered sources to all registered sinks.
+// It uses a RWMutex to ensure thread-safe concurrent modifications to the registry.
 type LogPipe struct {
     sync.RWMutex
     sources map[string]Source
     sinks map[string]Sink
 }
 
+// NewLogPipe initializes and returns a new LogPipe instance
+// with empty source and sink registries.
 func NewLogPipe() *LogPipe {
     return &LogPipe{
         sources: map[string]Source{},
@@ -29,18 +40,26 @@ func NewLogPipe() *LogPipe {
     }
 }
 
+// RegisterSource adds a new named Source to the pipeline.
+// It acquires a write lock to ensure thread safety while modifying the registry.
 func (l *LogPipe) RegisterSource(name string, source Source) {
     l.Lock()
     defer l.Unlock()
     l.sources[name] = source
 }
 
+// RegisterSink adds a new named Sink to the pipeline.
+// It acquires a write lock to ensure thread safety while modifying the registry.
 func (l *LogPipe) RegisterSink(name string, sink Sink) {
     l.Lock()
     defer l.Unlock()
     l.sinks[name] = sink
 }
 
+// broadcast sends the given message to all registered sinks.
+// It acquires a read lock to allow concurrent broadcasting while preventing
+// registry modifications during the iteration.
+// Note: This operation can block if a sink's channel is full.
 func (l *LogPipe) broadcast(source string, message string) {
     l.RLock()
     defer l.RUnlock()
@@ -50,6 +69,10 @@ func (l *LogPipe) broadcast(source string, message string) {
     }
 }
 
+// Tick performs a non-blocking read operation across all registered sources.
+// If a message is available from any source, it broadcasts it to all sinks
+// and returns true. If no messages are ready, it returns false immediately.
+// This allows the main loop to periodically poll for updates without getting stuck.
 func (l *LogPipe) Tick() (hasMessage bool) {
     hasMessage = false
     l.RLock()

--- a/register.go
+++ b/register.go
@@ -2,10 +2,17 @@ package logpipe
 
 import "github.com/lucasew/gocfg"
 
+// REGISTERED_SOURCES contains a mapping of source names to their respective factory functions.
+// These functions accept a configuration section and return a new Source instance or an error.
 var REGISTERED_SOURCES = map[string](func(gocfg.Section) (Source, error)){}
 
+// REGISTERED_SINKS contains a mapping of sink names to their respective factory functions.
+// These functions accept a configuration section and return a new Sink instance or an error.
 var REGISTERED_SINKS = map[string](func(gocfg.Section) (Sink, error)){}
 
+// init populates the global registries for built-in sources and sinks
+// with their corresponding factory functions (e.g., journalctl, telegram, discord).
+// This enables dynamic instantiation based on configuration files upon package load.
 func init() {
     REGISTERED_SOURCES["journalctl"] = NewJournalctlSource
     REGISTERED_SINKS["telegram"] = NewTelegramSink


### PR DESCRIPTION
Added crucial documentation to the core logging pipeline interfaces (`Source`, `Sink`), orchestrator (`LogPipe`), and the registry mechanism (`register.go`).

## Assumptions
- Go standard documentation conventions (`//`) should be used over JSDoc `/** */` for compatibility with Go ecosystem tools.
- The pipeline architecture utilizes a RWMutex for concurrent safety which was vital to document.
- I assumed the broken build on HEAD (`gocfg.Section` missing) was out-of-scope for a `Docs` agent since instructions explicitly forbade changing dependencies or executable logic.

## Alternatives Not Chosen
- Skipping internal methods like `broadcast` or `Tick` (Documented them because their blocking vs non-blocking behavior is a critical non-obvious detail).
- Creating external markdown diagrams (Kept focus on inline comments closest to the source of truth).

## How To Pivot
- To change the comment style (e.g. if you prefer less verbose comments), modify the block comments above `LogPipe` and its methods in `logpipe.go`.

## Next Knobs
- `logpipe.go`: Adjust the comments on `Tick` if the polling behavior changes.
- `register.go`: Add more documentation here if new Sink/Source types are introduced.
- Examine other undocumented packages like specific sinks (e.g., `discordsink.go`) for future PRs.

---
*PR created automatically by Jules for task [9316134101614574399](https://jules.google.com/task/9316134101614574399) started by @lucasew*