### PR TITLE
📝 Docs: Document sink implementations

### DIFF
--- a/consolesink.go
+++ b/consolesink.go
@@ -11,6 +11,9 @@ type ConsoleSink struct {
     started bool
 }
 
+// NewConsoleSink provides a simple sink that outputs messages to standard
+// logging output via an internal channel loop. It does not enforce
+// any specific rate limits.
 func NewConsoleSink(cfg gocfg.Section) (Sink, error) {
     return &ConsoleSink{
         ch: make(chan string, 1),

--- a/discordsink.go
+++ b/discordsink.go
@@ -21,6 +21,11 @@ var (
     ErrDiscordSinkNoWebhookProvided = errors.New("no webhook was provided")
 )
 
+// NewDiscordSink initializes a sink that dispatches messages to a Discord channel
+// via an asynchronous goroutine using a webhook URL.
+// It requires the "webhook" configuration key to be present in the provided section.
+// Messages are dispatched with an internal 200ms rate-limit to avoid hitting
+// API limits.
 func NewDiscordSink(cfg gocfg.Section) (Sink, error) {
     webhook, ok := cfg["webhook"]
     if !ok {

--- a/telegramsink.go
+++ b/telegramsink.go
@@ -17,6 +17,10 @@ type telegramSink struct {
     started bool
 }
 
+// NewTelegramSink initializes a sink that dispatches messages to a Telegram chat.
+// It requires both "chat_id" and "token" configuration keys. The sink operates
+// asynchronously, buffering messages up to a limit of 10 and processing them
+// with an internal 100ms rate-limit to avoid hitting the Telegram API limits.
 func NewTelegramSink(cfg gocfg.Section) (Sink, error) {
     return &telegramSink{
         cfg: cfg,


### PR DESCRIPTION
Assumptions:
- Standard Go `//` comment syntax is expected as this is a Go project.
- The `gocfg.Section` build error that appears when running `go build ./...` is due to a pre-existing broken dependency issue related to `gocfg` digest and should not be fixed in this PR because my scope is restricted strictly to adding/updating comments.

Alternatives Not Chosen:
- Grouping other missing documentation (like sources) in this same PR was avoided to keep the scope constrained to a single cohesive area.

How To Pivot:
- If standard JSDoc/TSDoc multi-line style `/** ... */` is preferred instead of Go `//` format, the comments can simply be rewrapped.

Next Knobs:
- The next logical step is to document the Source initializers (e.g., `NewJournalctlSource`) or the central `LogPipe` structural registry (`RegisterSource`, `RegisterSink`).

---
*PR created automatically by Jules for task [2790688397652845043](https://jules.google.com/task/2790688397652845043) started by @lucasew*